### PR TITLE
[Feat/#144-ranking] 포트폴리오 랭킹 갱신 및 조회 

### DIFF
--- a/module-exchange/src/main/java/com/example/module_exchange/clients/TripClient.java
+++ b/module-exchange/src/main/java/com/example/module_exchange/clients/TripClient.java
@@ -35,4 +35,6 @@ public interface TripClient {
     @GetMapping("/list")
     ResponseEntity<Response<List<TripGoalListResponseDTO>>> getListTripGoals(@RequestHeader(value = "X-Authenticated-User", required = false) int userId);
 
+    @GetMapping("/similar/{tripId}")
+    ResponseEntity<Response<List<Integer>>> getSimilarTrips(@PathVariable Integer tripId);
 }

--- a/module-exchange/src/main/java/com/example/module_exchange/exchange/ExchangeController.java
+++ b/module-exchange/src/main/java/com/example/module_exchange/exchange/ExchangeController.java
@@ -4,6 +4,7 @@ import com.example.module_exchange.exchange.exchangeCurrency.*;
 import com.example.module_exchange.exchange.stockTradeHistory.StockHoldingsDTO;
 import com.example.module_exchange.exchange.stockTradeHistory.StockTradeDTO;
 import com.example.module_exchange.exchange.stockTradeHistory.StockTradeService;
+import com.example.module_exchange.exchange.stockTradeHistory.TripRankingDTO;
 import com.example.module_exchange.exchange.transactionHistory.AccountListDTO;
 import com.example.module_exchange.exchange.transactionHistory.TransactionDTO;
 import com.example.module_exchange.exchange.transactionHistory.TransactionHistoryResponseDTO;
@@ -146,4 +147,21 @@ public class ExchangeController {
         return ResponseEntity.ok(Response.success(assessmentAmountSum));
     }
 
+    @GetMapping("/ranking/{tripId}")
+    public ResponseEntity<Response<List<TripRankingDTO>>> getRanking(@PathVariable Integer tripId, @RequestParam String currencyCode) {
+        List<TripRankingDTO> response = stockTradeService.getRanking(tripId, currencyCode);
+        return ResponseEntity.ok(Response.success(response));
+    }
+
+    @GetMapping("/ranking/all")
+    public ResponseEntity<Response<List<TripRankingDTO>>> getRanking(@RequestParam String currencyCode) {
+        List<TripRankingDTO> response = stockTradeService.getOverallRanking(currencyCode);
+        return ResponseEntity.ok(Response.success(response));
+    }
+
+    @PostMapping("/ranking/{tripId}")
+    public ResponseEntity<Response<Void>> updateRanking(@PathVariable Integer tripId, @RequestParam String currencyCode) {
+        stockTradeService.updateRanking(tripId, currencyCode);
+        return ResponseEntity.ok(Response.successWithoutData());
+    }
 }

--- a/module-exchange/src/main/java/com/example/module_exchange/exchange/stockTradeHistory/StockTradeService.java
+++ b/module-exchange/src/main/java/com/example/module_exchange/exchange/stockTradeHistory/StockTradeService.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.http.HttpEntity;
@@ -685,5 +686,79 @@ public class StockTradeService {
             logger.info("KRW 평가 손익: " + totalMtmProfitKRW);
 
         }
+    }
+    private String getRankingKey(String currencyCode) {
+        return "ranking:" + currencyCode;
+    }
+
+    //특정 trip 의 특정 주식 계좌 랭킹 업데이트
+    public void updateRanking(int tripId, String currencyCode){
+        BigDecimal assessmentAmountSum = calcAssessmentAmount(tripId, currencyCode);
+        double score = assessmentAmountSum.doubleValue();
+        String rankingKey = getRankingKey(currencyCode);
+        redisTemplate.opsForZSet().add(rankingKey, String.valueOf(tripId), score);
+        redisTemplate.expire(rankingKey, 3600, TimeUnit.SECONDS);
+    }
+
+    //전체 trip의 랭킹 update
+    public void updateRankingBatch(String currencyCode){
+        List<TripGoalResponseDTO> allTrips = tripClient.getAllTrips().getBody().getData();
+        for (TripGoalResponseDTO trip : allTrips) {
+            updateRanking(trip.getId(), currencyCode);
+        }
+        // redis pipeline으로 후에 리팩토링 가능
+    }
+
+    public List<TripRankingDTO> getRanking(int tripId, String currencyCode) {
+        List<Integer> similarTripIds = tripClient.getSimilarTrips(tripId).getBody().getData();
+        String rankingKey = getRankingKey(currencyCode);
+
+        Long size = redisTemplate.opsForZSet().size(rankingKey);
+        if(size == null || size==0){
+            updateRankingBatch(currencyCode);
+        }
+
+        Set<ZSetOperations.TypedTuple<String>> allRankings = redisTemplate.opsForZSet().reverseRangeWithScores(rankingKey, 0, -1);
+        List<TripRankingDTO> result = new ArrayList<>();
+
+        if (allRankings != null) {
+            for (ZSetOperations.TypedTuple<String> tuple : allRankings) {
+                String tripIdStr = tuple.getValue();
+                int trip = Integer.parseInt(tripIdStr);
+                if (similarTripIds.contains(trip)) {
+                    double score = tuple.getScore();
+                    result.add(TripRankingDTO.builder()
+                            .tripId(trip)
+                            .assessmentAmountSum(BigDecimal.valueOf(score)).build());
+                    if (result.size() >= 10) {
+                        break;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    public List<TripRankingDTO> getOverallRanking(String currencyCode) {
+        String rankingKey = getRankingKey(currencyCode);
+        Long size = redisTemplate.opsForZSet().size(rankingKey);
+        if (size == null || size == 0) {
+            updateRankingBatch(currencyCode);
+        }
+        Set<ZSetOperations.TypedTuple<String>> rankingSet = redisTemplate.opsForZSet()
+                .reverseRangeWithScores(rankingKey, 0, 9);
+        List<TripRankingDTO> result = new ArrayList<>();
+        if (rankingSet != null) {
+            for (ZSetOperations.TypedTuple<String> tuple : rankingSet) {
+                int trip = Integer.parseInt(tuple.getValue());
+                double score = tuple.getScore();
+                result.add(TripRankingDTO.builder()
+                        .tripId(trip)
+                        .assessmentAmountSum(BigDecimal.valueOf(score))
+                        .build());
+            }
+        }
+
+        return result;
     }
 }

--- a/module-exchange/src/main/java/com/example/module_exchange/exchange/stockTradeHistory/TripRankingDTO.java
+++ b/module-exchange/src/main/java/com/example/module_exchange/exchange/stockTradeHistory/TripRankingDTO.java
@@ -1,0 +1,17 @@
+package com.example.module_exchange.exchange.stockTradeHistory;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@Builder
+public class TripRankingDTO {
+    private Integer tripId;
+    private BigDecimal assessmentAmountSum;
+}


### PR DESCRIPTION
1. 전체 랭킹 갱신 api  : 모든 여행 목표에 대한 랭킹 갱신 
2. 특정 trip 랭킹 갱신 api : 특정 여행 목표에 대한 랭킹 갱신 
3. 전체 랭킹 조회 api : 모든 여행 목표에 대한 랭킹 조회 
4. 특정 trip과 유사한 목표에 대한 랭킹 조회 api : 목표가 비슷한(기간 & 금액) 랭킹 조회